### PR TITLE
Use a different cache directory foreach HEAD

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -75,5 +75,5 @@ grepcpan:
       git: '/home/toddr/git/bin/git'
    cache: 
       directory: '~APPDIR~/var/tmp'
-      version: '1.00'   
+      version: '1.01'
 

--- a/environments/development.yml
+++ b/environments/development.yml
@@ -30,4 +30,3 @@ grepcpan:
 #      git: '/usr/local/cpanel/3rdparty/bin/git'
    cache: 
       directory: '~APPDIR~/../var/tmp'
-      version: '1.05'

--- a/environments/metacpan.yml
+++ b/environments/metacpan.yml
@@ -23,4 +23,3 @@ grepcpan:
 #      git: '/home/toddr/git/bin/git'
    cache: 
       directory: '~APPDIR~/var/tmp'
-      version: '1.02'


### PR DESCRIPTION
GH #4

Use the git metacpan repo HEAD in the cache
directory name.

Simplify cache versions by only setting it
in the global configuration.

Add some fancy rules to purge as tmpwatch
seems to not be available.