### PR TITLE
Handle equal sign as a regular character

### DIFF
--- a/lib/grepcpan.pm
+++ b/lib/grepcpan.pm
@@ -347,7 +347,7 @@ sub _sanitize_search {
     $s =~ s{'}{\'}g;
 
     # whitelist possible characters ?
-    $s =~ s{[^\^a-zA-Z0-9\-\.\?\\*\&_'"~!\$\%()\[\]\{\}:;<>,/\@| ]}{}g;
+    $s =~ s{[^\^a-zA-Z0-9\-\.\?\\*\&_'"~!\$\%()\[\]\{\}:;<>,/\@| =]}{}g;
 
     return $s;
 }
@@ -356,7 +356,7 @@ sub _get_git_grep_flavor {
     my $s = shift;
 
     # regular characters
-    return q{--fixed-string} if $s =~ qr{^[a-zA-Z0-9&_'"~:;<>,/| ]+$};
+    return q{--fixed-string} if $s =~ qr{^[a-zA-Z0-9&_'"~:;<>,/| =]+$};
     return q{-P};
 }
 


### PR DESCRIPTION
reported as GH #20

the whitelist was not accepting '=' character
as a valid one.

This commit is adding '=' to the whitelist
and also to list of non pcre queries.